### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/GetDanmuAss/README.md
+++ b/GetDanmuAss/README.md
@@ -21,7 +21,7 @@ Danmaku2ASS(GetDanmuku(video.cid),r'%s/Desktop/%s.ass'%(os.path.expanduser('~'),
 
 ~~暂时不支持下载P2弹幕。。。后期会加上。。。~~ 【已支持】
 
-##鸣谢
+## 鸣谢
 
 我只是写了一下B站api获得弹幕，而转换模块基本参考[m13253](https://github.com/m13253)所写的[danmaku2ass](https://github.com/m13253/danmaku2ass)项目！！！
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##B站API收集整理及开发，测试【开发中】
+## B站API收集整理及开发，测试【开发中】
 ============
 
 ### 目录：
@@ -20,7 +20,7 @@
 * api.md   ：API的详细说明
 * README.md：return this
 
-###主要三部分API组成：
+### 主要三部分API组成：
 * 根据爬取页面获取到的信息：
   * 视频排行【已完成】
   * 根据条件筛选视频
@@ -37,9 +37,9 @@
   * 获取排行视频信息【已完成】
   * ...
 
-###类接口：
+### 类接口：
 
-####用户类：
+#### 用户类：
 ```python
 class User():
     def __init__(self,m_mid=None,m_name=None):
@@ -62,7 +62,7 @@ class User():
     followlist = None;#关注的好友列表
 ```
 
-####视频类：
+#### 视频类：
 ```python
 class Video():
     def __init__(self,m_aid=None,m_title=None):
@@ -93,19 +93,19 @@ class Video():
     episode = None;
     arcurl = None;#网页地址
     arcrank = None;#不明
-#不明：    
+# 不明：    
     tid = None;
     typename = None;
     instant_server = None;
     src = None;
     partname = None;
-#播放信息：
+# 播放信息：
     play_site = None;
     play_forward = None;
     play_mobile = None;
 ```
 
-####评论类：
+#### 评论类：
 ```
 class Comment():
     def __init__(self):
@@ -117,7 +117,7 @@ class Comment():
     post_user = None;
 ```
 
-####评论组(一组评论):
+#### 评论组(一组评论):
 ```
 class CommentList():
     def __init__(self):
@@ -127,7 +127,7 @@ class CommentList():
     page = None;
 ```
 
-####新番类：
+#### 新番类：
 ```
 class Bangumi():
     def __init__(self):

--- a/api.md
+++ b/api.md
@@ -1,11 +1,11 @@
-##直接爬取视频排行【已完成】:
+## 直接爬取视频排行【已完成】:
 * 获取URL: `http://www.bilibili.tv/list/[stow]-[zone]-[page]-[year1]-[month1]-[day1]~[year2]-[month2]-[day2].html`
 
 * 返回：只关于视频部分的源码
 
-###参数说明：
+### 参数说明：
 
-####Type:排序方式
+#### Type:排序方式
 * **收藏**：stow
 * **评论数**：review
 * **播放数**：hot
@@ -17,7 +17,7 @@
 
 >**注意：**上面排序方式中，**粗体字(前六个)**部分可以获取下文描述一切分区，但是*斜体(后两个)*只能获取二级以后的分区，也就是说**不可以**通过`拼音`和`投稿时间`来获取`综合排名`,`动画`,`音乐/舞蹈`,`游戏`,`科学技术`,`娱乐`,`影视`,`动画剧番`等分区。【可能是可以的，但是我没找到方法:-D】
 
-####zone：分区
+#### zone：分区
 * **综合排名**：0
 * **动画**：1
     * AMD·AMV：24
@@ -280,13 +280,13 @@ def GetPopularVideo(begintime,endtime,sortType=TYPE_BOFANG,zone=0,page=1,origina
     
 ---
 
-##视频Index
+## 视频Index
 * 获取URL: `http://www.bilibili.tv/list/b-[firstlatter]-[zone]-[time]-[catalog]-[state]-[style]-[updatetime]-[sorttype]-[weekday]--[page].html`
 
 * 返回：整个网页源代码
 
 
-###参数说明：
+### 参数说明：
 #### zone:地区
 * 不限：a
 * 中国大陆：a1
@@ -361,13 +361,13 @@ def GetPopularVideo(begintime,endtime,sortType=TYPE_BOFANG,zone=0,page=1,origina
 #### page：页数
 必填，1~n
 
-##按月份获取`动画`新番
+## 按月份获取`动画`新番
 * 获取URL: `http://www.bilibili.tv/index/bangumi/[year]-[month].json`
 
 * 返回：json信息
 
-###参数说明：
-####输入：
+### 参数说明：
+#### 输入：
 * year:年份  四位数
 * month:月份
 
@@ -382,7 +382,7 @@ def GetPopularVideo(begintime,endtime,sortType=TYPE_BOFANG,zone=0,page=1,origina
 
 ---
 
-##B站API(无需认证或登录即可爬取的部分)：
+## B站API(无需认证或登录即可爬取的部分)：
 **获取本周排行**
 * URL：【返回json】
     * `http://api.bilibili.cn/index`
@@ -995,7 +995,7 @@ GetBangumiInfo(bgm_id)
 
 ---
 
-##B站API(需认证)：
+## B站API(需认证)：
 > 下方所有调用api方法均要加入`appkey=...`,如果是新注册的appkey的话还需要加入sign，具体算法是：
 python：
 ```python


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
